### PR TITLE
Modelとmigrationファイルの作成 | feature/dbMigrate

### DIFF
--- a/app/Comment.php
+++ b/app/Comment.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    //
+}

--- a/app/Post.php
+++ b/app/Post.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    //
+}

--- a/database/migrations/2021_08_20_101947_create_posts_table.php
+++ b/database/migrations/2021_08_20_101947_create_posts_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id'); //外部キー（他テーブルのIDを参照）
+            $table->string('title');
+            $table->string('body');
+
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('posts');
+    }
+}

--- a/database/migrations/2021_08_20_102010_create_comments_table.php
+++ b/database/migrations/2021_08_20_102010_create_comments_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCommentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('comments', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id'); //外部キー（他テーブルのIDを参照）
+            $table->unsignedBigInteger('post_id'); //外部キー（他テーブルのIDを参照）
+            $table->string('body');
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users');
+            $table->foreign('post_id')->references('id')->on('posts');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('comments');
+    }
+}


### PR DESCRIPTION
**databaseのmigration**
・phpmyadminでtableを作成

・`.env`ファイルの内容修正

・`php artisan migrate`



Modelとmigrationファイルの作成はこれが楽

```
php artisan make:model Post --migration
```

migrationとmodelが同時に作成される
DBは原則複数形にすること！！
→今回はforumと単数形にしている（phpmyadminを見る）



エラー：SQLSTATE[42S01]: Base table or view already exists:...

```
php artisan migrate:fresh
```

これで解決