### PR TITLE
各ユーザー限定の機能仕様へ変更 | Feature/010 setting orig user

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -97,6 +97,11 @@ class PostController extends Controller
     public function update(Request $request, $id)
     {
         $post = Post::find($id);
+
+        if(Auth::id() !== $post->user_id) {
+            return abort(404);
+        }
+        
         $post->title = $request->title;
         $post->body = $request->body;
         $post->timestamps = false; //一時追加（timestampなしで検証）
@@ -114,6 +119,11 @@ class PostController extends Controller
     public function destroy($id)
     {
         $post = Post::find($id);
+
+        if(Auth::id() !== $post->user_id) {
+            return abort(404);
+        }
+
         $post->delete();
 
         return redirect()->route('posts.index');

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -4,7 +4,7 @@
 <div class="container">
   <div class="row justify-content-center">
     <div class="col-md-8">
-      <h1>一覧ページ</h1>
+      <h1>詳細ページ</h1>
       <a href="{{ route('posts.create') }}" class="btn btn-primary">新規投稿</a>
       <div class="card text-center">
         <div class="card-header">

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -14,11 +14,13 @@
           <h5 class="card-title">タイトル：{{ $post->title}}</h5>
           <p class="card-text">内容：{{$post->body}}</p>
           <a href="{{ route('posts.edit', $post->id) }}" class="btn btn-primary">編集画面へ</a>
+          @if( $post->user_id === Auth::id() )
           <form action="{{ route('posts.destroy', $post->id)}}" method='post'>
             @csrf
             {{ method_field('DELETE') }}
             <input type='submit' value='削除' class="btn btn-danger" onclick='return confirm("削除しますか？？");'>
           </form>
+          @endif
         </div>
         <div class="card-footer text-muted">
           投稿日：

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -13,8 +13,8 @@
         <div class="card-body">
           <h5 class="card-title">タイトル：{{ $post->title}}</h5>
           <p class="card-text">内容：{{$post->body}}</p>
-          <a href="{{ route('posts.edit', $post->id) }}" class="btn btn-primary">編集画面へ</a>
           @if( $post->user_id === Auth::id() )
+          <a href="{{ route('posts.edit', $post->id) }}" class="btn btn-primary">編集画面へ</a>
           <form action="{{ route('posts.destroy', $post->id)}}" method='post'>
             @csrf
             {{ method_field('DELETE') }}


### PR DESCRIPTION


・投稿した人以外が削除できないようにする

→削除できません画面を作成

→勝手に内容を変えられたり、勝手に内容を更新させたりしてしまうのはまずい。



投稿IDとログインIDとちがったら

違うページに飛ばしたい

→こうすると他人から削除されなくなる



削除ボタンが出てしまうのは大変なので、ログインしてるユーザーIDと投稿のユーザーIDが同じであれば、

削除ボタンを表示させるというロジックを追加

↓

自分の投稿なら編集ボタンと削除ボタンが表示される形式に変更



git commitのコメントを変更

```
git commit --amend -m "cssを修正"
```