### PR TITLE
投稿内容にユーザーを追加 | feature/012_connectRelation

### DIFF
--- a/app/Comment.php
+++ b/app/Comment.php
@@ -7,4 +7,14 @@ use Illuminate\Database\Eloquent\Model;
 class Comment extends Model
 {
     protected $fillable = ['body'];
+
+    public function post() 
+    {
+    return $this->belongsTo('App\Post');
+    }
+
+    public function user() 
+    {
+    return $this->belongsTo('App\Post');
+    }
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -7,4 +7,14 @@ use Illuminate\Database\Eloquent\Model;
 class Post extends Model
 {
     protected $fillable = ['title', 'body'];
+
+    public function comments()
+    {
+        return $this->hasMany('App\Comment');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo('App\User');
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -35,4 +35,14 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    public function posts()
+    {
+        return $this->hasMany('App\Post');
+    }
+
+    public function comments()
+    {
+        return $this->hasMany('App\Comment');
+    }
 }

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -14,6 +14,7 @@
         <div class="card-body">
           <h5 class="card-title">タイトル：{{ $post->title}}</h5>
           <p class="card-text">内容：{{$post->body}}</p>
+          <p class="card-text">投稿者：{{$post->user->name}}</p>
           <a href="{{ route('posts.show', $post->id) }}" class="btn btn-primary">詳細</a>
         </div>
         <div class="card-footer text-muted">


### PR DESCRIPTION
### 一覧ページで誰の投稿かをわかるようにする

`hasMany('App\Post')`
ユーザーはたくさんのPostがある

ポストはたくさんのコメントがある

ポストはひとつのユーザーしかもたない

`belongsTo`
→hasManyの反対はこう書く

コメントはどこの投稿の話かを明確に。
コメントは1つのpostにbelongsToしてる
