### PR TITLE
コメントの表示と投稿日時の追加

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -3,12 +3,19 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Http\Requests\CommentRequest;
 use Auth;
 use App\Comment;
 use App\Post;
 
 class CommentController extends Controller
 {
+
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
     /**
      * Display a listing of the resource.
      *
@@ -33,12 +40,13 @@ class CommentController extends Controller
      * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request)
+    public function store(CommentRequest $request)
     {
         $comment = new Comment;
         $comment->body = $request->body;
         $comment->user_id = Auth::id();
         $comment->post_id = $request->post_id;
+        $comment->created_at;
 
         $comment->save();
 
@@ -56,6 +64,11 @@ class CommentController extends Controller
      */
     public function show($id)
     {
+        $post = Post::find($id);
+
+        $comments = Comment::where('post_id', $id)->get();
+
+        return view('posts.show', compact('post', 'comments'));
     }
 
     /**

--- a/app/Http/Requests/CommentRequest.php
+++ b/app/Http/Requests/CommentRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CommentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+       return [
+            'body' => 'required',
+       ];
+    }
+
+    public function message()
+    {
+        return [
+            'body.required' => '内容は必須です。',
+        ];
+    } 
+}

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -41,5 +41,18 @@
       </form>
     </div>
   </div>
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      @foreach ($post->comments as $comment)
+      <div class="card mt-3">
+        <h5 class="card-header">投稿者：{{$comment->user->name}}</h5>
+        <div class="card-body">
+          <h5 class="card-title">投稿日時：{{$comment->created_at}}</h5>
+          <p class="card-text">内容：{{$comment->body}}</p>
+        </div>
+      </div>
+      @endforeach
+    </div>
+  </div>
 </div>
 @endsection


### PR DESCRIPTION
投稿画面の詳細ページに紐づくコメントを表示

Requests/CommentRequest fileを作成するコマンド
```
php artisan make:request CommentRequest
```

コメントの表示はPostControllerのshow function(methods)に書いていく
idを見つけて、コメントを抽出

whereは何かの条件で探したいときに使う
※SQLのWHEREと同じ

コメントにはおそらくpost_id columnがある、その中の$idでフィールドを指定する
```
$comments = Comment::where('post_id', $id)->get;
```

これでpost_idに紐づいた、$idをgetすることができる
$commentsを渡しているので、これをforeachで回す